### PR TITLE
Enforce err handling in Node.js style callbacks.

### DIFF
--- a/documentation/handle-callback-err.md
+++ b/documentation/handle-callback-err.md
@@ -28,3 +28,16 @@ handleCallback(function ignoreError(err) {
     if (err) {}
 });
 ```
+
+It will work with [passerror](https://www.npmjs.com/package/passerror):
+
+```js
+var passError = require('passerror');
+var fs = require('fs');
+
+function errHandler() {}
+
+fs.readFile('/foo.txt', passError(errHandler, function (data) {
+    console.log(data);
+}));
+```

--- a/documentation/handle-callback-err.md
+++ b/documentation/handle-callback-err.md
@@ -1,0 +1,30 @@
+You must handle err arguments in callbacks.
+
+```js
+function handleCallback() {}
+
+handleCallback(function (err, data) {
+    // err not handled
+});
+```
+
+```output
+Line 6, column 16: Expected error to be handled.
+```
+
+The following are examples of correct behavior.
+
+```js
+function handleCallback() {}
+
+handleCallback(function loadData(err, data) {
+    if (err) {
+        console.log(err.stack);
+    }
+}
+);
+
+handleCallback(function ignoreError(err) {
+    if (err) {}
+});
+```

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -21,6 +21,7 @@
         "dot-notation": [2, { "allowKeywords": true }],
         "eol-last": [2],
         "eqeqeq": [2],
+        "handle-callback-err": [2],
         "indent": [2, 4],
         "keyword-spacing": [2],
         "new-cap": [2, {"capIsNew": false}],


### PR DESCRIPTION
Fixes #4 

http://eslint.org/docs/rules/handle-callback-err.html

This is a breaking change to be included in v2.

RFR @joelmukuthu @papandreou 