### PR TITLE
add object-property-newline rule

### DIFF
--- a/documentation/object-property-newline.md
+++ b/documentation/object-property-newline.md
@@ -1,0 +1,33 @@
+Object properties should be spread across different lines:
+
+```js
+/* eslint no-unused-vars: 0 */
+
+var foo = {
+    foo: 'bar',
+    bar: 'foo'
+};
+```
+
+Or all be on the same line:
+
+```js
+/* eslint no-unused-vars: 0 */
+
+var foo = { foo: 'bar', bar: 'foo' };
+```
+
+But not mixing the cases.
+
+```js
+/* eslint no-unused-vars: 0 */
+
+var foo = {
+    foo: 'bar', bar: 'baz',
+    qux: 'baz'
+};
+```
+
+```output
+Line 26, column 17: Object properties must go on a new line if they aren't all on the same line
+```

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -38,6 +38,7 @@
         "no-unreachable": [2],
         "no-unused-vars": [2, { "args": "none" }],
         "no-with": [2],
+        "object-property-newline": [2, { "allowMultiplePropertiesPerLine": true }],
         "semi": [2, "always"],
         "space-before-function-paren": [2, {"anonymous": "always", "named": "never"} ],
         "space-before-blocks": [2, { "functions": "always" } ],

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/One-com/eslint-config-onelint#readme",
   "devDependencies": {
-    "eslint": "2.4.0",
+    "eslint": "2.13.1",
     "eslint-markdown-test": "1.1.0",
     "mocha": "2.3.4"
   }


### PR DESCRIPTION
This bumps the version requirement of eslint to `^2.10.0`.

RFR @papandreou @PabloSichert @joelmukuthu