### PR TITLE
Support eslint 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint": "^4"
   },
   "devDependencies": {
-    "eslint": "^4.11.0",
+    "eslint": "^5.0.0",
     "eslint-markdown-test": "1.1.0",
     "mocha": "2.3.4"
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/One-com/eslint-config-onelint#readme",
   "peerDependencies": {
-    "eslint": "^4"
+    "eslint": "^4 || ^5"
   },
   "devDependencies": {
     "eslint": "^5.0.0",


### PR DESCRIPTION
The peer dep of `"eslint": "^4"` currently makes the package fail to install on node.js 4 (npm 2.x) in projects that want to upgrade to eslint 5.

See https://github.com/unexpectedjs/unexpected-sinon/pull/58